### PR TITLE
Add /discord path that redirects to ICSSC's Discord invite

### DIFF
--- a/discord.html
+++ b/discord.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>ICSSC's Discord</title>
+
+    <!-- Meta -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="keywords" content="ICSSC, ICSSC UCI, ICS Student Council">
+    <meta name="description" content="For students. By students.">
+    <meta name="author" content="ICSSC">
+
+    <!-- Favicon -->
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
+    <link rel="mask-icon" href="favicon/safari-pinned-tab.svg" color="#4282fb">
+    <link rel="shortcut icon" href="favicon/favicon.ico">
+    <meta name="msapplication-TileColor" content="#2d89ef">
+    <meta name="msapplication-config" content="favicon/browserconfig.xml">
+    <meta name="theme-color" content="#ffffff">
+
+    <script type="text/javascript">
+      window.location.replace("https://discord.gg/c4t5dGcM9S");
+    </script>
+  </head>
+</html>


### PR DESCRIPTION
This adds a path that redirects to our ICSSC Discord invite. 
So studentcouncil.ics.uci.edu/discord -> https://discord.gg/c4t5dGcM9S (ICSSC Discord)