### PR TITLE
Update sponsors page

### DIFF
--- a/pages/sponsors.js
+++ b/pages/sponsors.js
@@ -6,16 +6,17 @@ function Sponsor(props) {
   const {id, name, description, link, logo} = props;
 
   return (
-    <section id={id}>
-      <Container>
-        <Row>
-          <Col lg={6}>
+    <div id={id}>
+      <>
+        <Row className="mb-5">
+          <Col lg={6} className='align-self-center'>
             <a href={link}>
-              <Image 
+              <img 
                 src={logo}
                 alt={`${name} logo`}
-                height={300}
-                width={300}
+                width='300'
+                height='150'
+                style={{objectFit:"contain"}}
               />
             </a>
           </Col>
@@ -26,23 +27,19 @@ function Sponsor(props) {
             <p>{description}</p>
           </Col>
         </Row>
-      </Container>
-    </section>
+      </>
+    </div>
   )
 }
 
 export default function Sponsors() {
   return (
-    <>
-      <h1>Sponsors</h1>
-      <main>
-        <Container>
-          <header>
-            <h2>Our 2020 Sponsors</h2>
-          </header>
-          {SponsorsData.map(sponsor => <Sponsor {...sponsor}/>)}
-        </Container>
-      </main>
-    </>
+    <Container>
+      <div className="banner">
+        <h1>Sponsors</h1>
+      </div>
+      <h2>Our 2020 Sponsors</h2>
+      {SponsorsData.map(sponsor => <Sponsor {...sponsor} key={sponsor.name}/>)}
+    </Container>
   )
 }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -52,6 +52,23 @@ a {
   box-sizing: border-box;
 }
 
+.banner {
+  margin-top: 6rem;
+  text-align: center;
+  text-align: -webkit-center;
+  h1 {
+      margin: 2rem 0;
+      font-size: 4rem;
+      font-weight: 800;
+  }
+  p {
+      font-size: 1.3rem;
+      max-width: 800px;
+      display: inline;
+      vertical-align: middle;
+  }
+}
+
 .section, .sectionAlt {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Sponsors page left unchanged, few layout changes
## Page Preview
![image](https://user-images.githubusercontent.com/65209258/212582544-644c8188-42e5-4816-af48-023ff3de109a.png)

## Test Plan

## Issues
Closes # 


## Future Followup  
Probably the only page using React Bootstrap layout components. May want to change it to straight CSS in the future, but since it isn't an important page, it can be left as is.
