### PR TITLE
fix: Remove Duplicate Committee Element, Update Bits & Bytes, Correct Events Page

### DIFF
--- a/pages/events.js
+++ b/pages/events.js
@@ -1,11 +1,11 @@
 import { Row, Button, Modal } from "react-bootstrap";
-import EventsData from '../assets/data/events.json';
-import React, { useState } from 'react';
+import EventsData from "../assets/data/events.json";
+import React, { useState } from "react";
 
-import styles from '/styles/Events.module.scss';
+import styles from "/styles/Events.module.scss";
 
 function EventModal(props) {
-  const {src, title, time, location, desc, iscurrent, rsvp_src} = props;
+  const { src, title, time, location, desc, iscurrent, rsvp_src } = props;
   return (
     <Modal
       {...props}
@@ -14,37 +14,38 @@ function EventModal(props) {
       centered
     >
       <Modal.Header closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
-          {title}
-        </Modal.Title>
+        <Modal.Title id="contained-modal-title-vcenter">{title}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <p>{time} | {location}</p>
+        <p>
+          {time} | {location}
+        </p>
         {desc}
       </Modal.Body>
       <Modal.Footer>
-        {rsvp_src && <Button variant="success" href={rsvp_src}>RSVP</Button>}
+        {rsvp_src && (
+          <Button variant="success" href={rsvp_src}>
+            RSVP
+          </Button>
+        )}
         <Button onClick={props.onHide}>Close</Button>
       </Modal.Footer>
     </Modal>
   );
 }
 
-
 function Event(props) {
   const [modalShow, setModalShow] = useState(false);
-  const {src, title, time, location, desc, iscurrent, rsvp_src} = props;
+  const { src, title, time, location, desc, iscurrent, rsvp_src } = props;
   return (
     <>
       <div className={`${styles.eventBox}`} onClick={() => setModalShow(true)}>
-          <img
-              src={src}
-          />
-          <h4 style={{marginTop:"10px", fontWeight:"600"}}>
-              {title}
-          </h4>
-          <p>{location}<br/> {time}</p>
-          
+        <img src={src} />
+        <h4 style={{ marginTop: "10px", fontWeight: "600" }}>{title}</h4>
+        <p>
+          {location}
+          <br /> {time}
+        </p>
       </div>
       <EventModal
         show={modalShow}
@@ -65,31 +66,33 @@ export default function Events() {
     <>
       {/* Event Title Section */}
       <div className="sectionAlt">
-      <h2>Upcoming Events</h2>
-      {<p>No current events! Stay tuned for more :)</p>}
-      {/* Uncomment This To Display Current Events */}
-      <Row style={{justifyContent:"center"}}>
-        <div className={`${styles.sectionEvents} `}>
-          <div className={`${styles.eventsGrid}`}>
-              {EventsData["current"].map(past => <Event {...past} iscurrent="true" key={past.title}/>)}
+        <h2>Upcoming Events</h2>
+        {/* {<p>No current events! Stay tuned for more :)</p>} */}
+        {/* Uncomment This To Display Current Events */}
+        <Row style={{ justifyContent: "center" }}>
+          <div className={`${styles.sectionEvents} `}>
+            <div className={`${styles.eventsGrid}`}>
+              {EventsData["current"].map((past) => (
+                <Event {...past} iscurrent="true" key={past.title} />
+              ))}
+            </div>
           </div>
-        </div>
-      </Row>
+        </Row>
       </div>
 
-      
       {/* Event Past Section */}
       <div className="section">
         <h2>Past Events</h2>
-        <Row style={{justifyContent:"center"}}>
-        <div className={`${styles.sectionEvents} `}>
-          <div className={`${styles.eventsGrid}`}>
-              {EventsData["past"].map(past => <Event {...past} isCurrent={false} key={past.title}/>)}
+        <Row style={{ justifyContent: "center" }}>
+          <div className={`${styles.sectionEvents} `}>
+            <div className={`${styles.eventsGrid}`}>
+              {EventsData["past"].map((past) => (
+                <Event {...past} isCurrent={false} key={past.title} />
+              ))}
+            </div>
           </div>
-        </div>
         </Row>
       </div>
-      
     </>
-  )
+  );
 }

--- a/pages/get-involved.js
+++ b/pages/get-involved.js
@@ -63,10 +63,10 @@ export default function GetInvolved() {
 
         <div className={styles.oneContainer}>
           <h2>The Bits & Bytes Program</h2>
-          {/* <b>
-            Applications are closed. Check back in Fall Quarter for recruitment.
-          </b> */}
           <b>
+            Applications are closed. Check back in Fall Quarter for recruitment.
+          </b>
+          {/* <b>
             <a
               href="https://docs.google.com/spreadsheets/d/1U6If78kK7aEvHrwo-7_aZIbEl9BD60Ka4jJn5mSD1xg/edit#gid=0"
               target="_blank"
@@ -81,7 +81,7 @@ export default function GetInvolved() {
             >
               Apply Here! Applications are due 10/22!
             </a>
-          </b>
+          </b> */}
           <p>
             Bits & Bytes is a year long mentorship program organized by ICS
             Student Council at UC Irvine to help new ICS students transition to

--- a/pages/get-involved.js
+++ b/pages/get-involved.js
@@ -55,8 +55,16 @@ export default function GetInvolved() {
 
         <div className={styles.oneContainer}>
           <h2>The Bits & Bytes Program</h2>
-          <b>
+          {/* <b>
             Applications are closed. Check back in Fall Quarter for recruitment.
+          </b> */}
+          <b>
+            <a href="https://docs.google.com/spreadsheets/d/1U6If78kK7aEvHrwo-7_aZIbEl9BD60Ka4jJn5mSD1xg/edit#gid=0">
+              Read Byte Intros Here!
+            </a>
+            <a href="https://docs.google.com/forms/d/e/1FAIpQLSdqhDUzTZsY4fGt9GIdSp1wm_DRxskmv_EYQwKCbGM-X1JREQ/viewform">
+              Apply Here! Applications are due 10/22!
+            </a>
           </b>
           <p>
             Bits & Bytes is a year long mentorship program organized by ICS

--- a/pages/get-involved.js
+++ b/pages/get-involved.js
@@ -1,12 +1,13 @@
 import CommitteesJSON from "../assets/data/committees.json";
-import { Row, Col, Container, Button } from "react-bootstrap";
+import { Container } from "react-bootstrap";
 import styles from "/styles/GetInvolved.module.scss";
+import Image from "next/image";
 
 function Committee(props) {
   const { name, short_desc, graphic } = props;
   return (
     <div className={styles.committee}>
-      <img src={graphic} alt={name} />
+      <Image src={graphic} alt={name} width={300} height={200} />
       <h5>{name}</h5>
       <p>{short_desc}</p>
     </div>
@@ -20,8 +21,8 @@ export default function GetInvolved() {
         <h1>Get Involved in ICSSC</h1>
         <p>
           ICSSC offers a variety of committees and programs that any student can
-          be apart of. Don't feel like committing too much time? Don't worry!
-          Everyone can attend our meetings and workshops!
+          be apart of. {"Don't"} feel like committing too much time? {"Don't "}
+          worry! Everyone can attend our meetings and workshops!
         </p>
 
         <div className={styles.oneContainer}>
@@ -67,22 +68,26 @@ export default function GetInvolved() {
 
           <div className={styles.halfContainer}>
             <div>
-              <img
+              <Image
                 src={"/assets/img/graphics/BeABitByte.png"}
                 alt={"Be a Bit/Byte"}
+                width={300}
+                height={200}
               />
               <h3>Be a Bit/Byte</h3>
               <p>
-                Here's your chance by applying to become a bit or byte! As a
+                {"Here's"} your chance by applying to become a bit or byte! As a
                 byte you are going to be the mentor, the role model, and most
                 importantly of all, your best friend to your bit! As for bits,
                 have fun!
               </p>
             </div>
             <div>
-              <img
+              <Image
                 src={"/assets/img/graphics/JoinAFamily.png"}
                 alt={"Join a Family"}
+                width={300}
+                height={200}
               />
               <h3>Join a Family</h3>
               <p>

--- a/pages/get-involved.js
+++ b/pages/get-involved.js
@@ -43,9 +43,7 @@ export default function GetInvolved() {
         <div className={styles.oneContainer}>
           <h2>Apply To Our Committees</h2>
           {/* <b>Applications are closed. Check back in Fall Quarter for recruitment.</b> */}
-          <b>
-            Applications are closed. Check back in Fall Quarter for recruitment.
-          </b>
+          <b>Applications are open!</b>
           <p> ICS Students can apply to any of the following committees.</p>
           <div className={styles.committeeContainer}>
             {CommitteesJSON.map((committee) => (

--- a/pages/get-involved.js
+++ b/pages/get-involved.js
@@ -59,10 +59,18 @@ export default function GetInvolved() {
             Applications are closed. Check back in Fall Quarter for recruitment.
           </b> */}
           <b>
-            <a href="https://docs.google.com/spreadsheets/d/1U6If78kK7aEvHrwo-7_aZIbEl9BD60Ka4jJn5mSD1xg/edit#gid=0">
+            <a
+              href="https://docs.google.com/spreadsheets/d/1U6If78kK7aEvHrwo-7_aZIbEl9BD60Ka4jJn5mSD1xg/edit#gid=0"
+              target="_blank"
+              rel="noreferrer"
+            >
               Read Byte Intros Here!
             </a>
-            <a href="https://docs.google.com/forms/d/e/1FAIpQLSdqhDUzTZsY4fGt9GIdSp1wm_DRxskmv_EYQwKCbGM-X1JREQ/viewform">
+            <a
+              href="https://docs.google.com/forms/d/e/1FAIpQLSdqhDUzTZsY4fGt9GIdSp1wm_DRxskmv_EYQwKCbGM-X1JREQ/viewform"
+              target="_blank"
+              rel="noreferrer"
+            >
               Apply Here! Applications are due 10/22!
             </a>
           </b>

--- a/pages/get-involved.js
+++ b/pages/get-involved.js
@@ -44,7 +44,15 @@ export default function GetInvolved() {
         <div className={styles.oneContainer}>
           <h2>Apply To Our Committees</h2>
           {/* <b>Applications are closed. Check back in Fall Quarter for recruitment.</b> */}
-          <b>Applications are open!</b>
+          <b>
+            <a
+              href="https://forms.gle/oXRCES81JUihBy789"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Applications are open!
+            </a>
+          </b>
           <p> ICS Students can apply to any of the following committees.</p>
           <div className={styles.committeeContainer}>
             {CommitteesJSON.map((committee) => (

--- a/pages/get-involved.js
+++ b/pages/get-involved.js
@@ -1,20 +1,16 @@
-import CommitteesJSON from '../assets/data/committees.json';
-import { Row, Col, Container, Button } from 'react-bootstrap';
+import CommitteesJSON from "../assets/data/committees.json";
+import { Row, Col, Container, Button } from "react-bootstrap";
 import styles from "/styles/GetInvolved.module.scss";
 
-
 function Committee(props) {
-  const {name, short_desc, graphic} = props;
+  const { name, short_desc, graphic } = props;
   return (
     <div className={styles.committee}>
-      <img
-        src={graphic}
-        alt={name}
-      />
+      <img src={graphic} alt={name} />
       <h5>{name}</h5>
       <p>{short_desc}</p>
     </div>
-  )
+  );
 }
 
 export default function GetInvolved() {
@@ -22,78 +18,117 @@ export default function GetInvolved() {
     <Container>
       <div className={styles.section}>
         <h1>Get Involved in ICSSC</h1>
-        <p>ICSSC offers a variety of committees and programs that any student can be apart of. Don't feel like committing too much time? Don't worry! Everyone can attend our meetings and workshops!</p>
-        
+        <p>
+          ICSSC offers a variety of committees and programs that any student can
+          be apart of. Don't feel like committing too much time? Don't worry!
+          Everyone can attend our meetings and workshops!
+        </p>
+
         <div className={styles.oneContainer}>
           <h2>Our Newsletter</h2>
-          <p>Sign up to recieve email updates on our events, promotions, announcements, and more!</p>
-          
-          <a href="https://icssc.link/ICSSCNewsletter" rel="noreferrer" target="_blank">Sign Up Here</a>
-          </div> 
+          <p>
+            Sign up to recieve email updates on our events, promotions,
+            announcements, and more!
+          </p>
 
+          <a
+            href="https://icssc.link/ICSSCNewsletter"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Sign Up Here
+          </a>
+        </div>
 
-          <div className={styles.oneContainer}>
-            <h2>Apply To Our Committees</h2>
-            <b>Applications are closed. Check back in Fall Quarter for recruitment.</b>
-            <p> ICS Students can apply to any of the following committees.</p>
-            <div className={styles.committeeContainer}>
-              {CommitteesJSON.map(committee => <Committee {...committee} key={committee.name}/>)}
+        <div className={styles.oneContainer}>
+          <h2>Apply To Our Committees</h2>
+          {/* <b>Applications are closed. Check back in Fall Quarter for recruitment.</b> */}
+          <b>
+            Applications are closed. Check back in Fall Quarter for recruitment.
+          </b>
+          <p> ICS Students can apply to any of the following committees.</p>
+          <div className={styles.committeeContainer}>
+            {CommitteesJSON.map((committee) => (
+              <Committee {...committee} key={committee.name} />
+            ))}
           </div>
         </div>
 
         <div className={styles.oneContainer}>
           <h2>The Bits & Bytes Program</h2>
-          <b>Applications are closed. Check back in Fall Quarter for recruitment.</b>
-          <p>Bits & Bytes is a year long mentorship program organized by ICS Student Council at UC Irvine to help new ICS students transition to life at UCI through organized socials! Group leaders, aka Bytes, will guide and provide a community at UCI for incoming freshmen and transfers, aka Bits.</p>
-          
+          <b>
+            Applications are closed. Check back in Fall Quarter for recruitment.
+          </b>
+          <p>
+            Bits & Bytes is a year long mentorship program organized by ICS
+            Student Council at UC Irvine to help new ICS students transition to
+            life at UCI through organized socials! Group leaders, aka Bytes,
+            will guide and provide a community at UCI for incoming freshmen and
+            transfers, aka Bits.
+          </p>
+
           <div className={styles.halfContainer}>
             <div>
               <img
-                src={'/assets/img/graphics/BeABitByte.png'}
-                alt={'Be a Bit/Byte'}
+                src={"/assets/img/graphics/BeABitByte.png"}
+                alt={"Be a Bit/Byte"}
               />
               <h3>Be a Bit/Byte</h3>
-              <p>Here's your chance by applying to become a bit or byte! As a byte you are going to be the mentor, the role model, and most importantly of all, your best friend to your bit! As for bits, have fun!</p>
+              <p>
+                Here's your chance by applying to become a bit or byte! As a
+                byte you are going to be the mentor, the role model, and most
+                importantly of all, your best friend to your bit! As for bits,
+                have fun!
+              </p>
             </div>
             <div>
-            <img
-              src={'/assets/img/graphics/JoinAFamily.png'}
-              alt={'Join a Family'}
-            />
+              <img
+                src={"/assets/img/graphics/JoinAFamily.png"}
+                alt={"Join a Family"}
+              />
               <h3>Join a Family</h3>
-              <p>In a Bits & Byte Fam, there are 2 bytes with 2-6 bytes each! Stay connected with the ICS community through events that promote academic success and community bonding</p>
+              <p>
+                In a Bits & Byte Fam, there are 2 bytes with 2-6 bytes each!
+                Stay connected with the ICS community through events that
+                promote academic success and community bonding
+              </p>
             </div>
           </div>
         </div>
-        
+
         <div className={styles.oneContainer}>
           <h2>The Fellowship Program</h2>
-          <p>The Fellowship is an asynchronous web development crash course that teaches fundamental software development skills. By the end of the course, students will have the skillset necessary to create their own React websites and will have the opportunity to contribute to one our ICSSC Projects such as AntAlmanac, PeterPortal, or Zotistics!</p>
-          
-          <a href="https://fellowship.icssc.club/" rel="noreferrer" target="_blank">View Fellowship</a>
-          </div> 
+          <p>
+            The Fellowship is an asynchronous web development crash course that
+            teaches fundamental software development skills. By the end of the
+            course, students will have the skillset necessary to create their
+            own React websites and will have the opportunity to contribute to
+            one our ICSSC Projects such as AntAlmanac, PeterPortal, or
+            Zotistics!
+          </p>
 
-
-          <div className={styles.oneContainer}>
-            <a href="https://icssc.link/CommitteeApplication2023" rel="noreferrer" target="_blank">
-              <h2>Apply To Our Committees</h2>
-            </a>
-            {/* <b>Applications are closed. Check back in Fall Quarter for recruitment.</b> */}
-            <b>
-              Applications are open!
-            </b>
-            <p> ICS Students can apply to any of the following committees.</p>
-            <div className={styles.committeeContainer}>
-              {CommitteesJSON.map(committee => <Committee {...committee} key={committee.name}/>)}
-          </div>
+          <a
+            href="https://fellowship.icssc.club/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            View Fellowship
+          </a>
         </div>
-        
+
         <div className={styles.oneContainer}>
           <h2>Apply to Our Board</h2>
-          <b>Applications are closed. Check back in Spring Quarter for applications.</b>
-          <em>Running for President, Internal VP, or External VP, requires that you have already been a full-member for Fall, Winter, and Spring Quarter.</em>      
+          <b>
+            Applications are closed. Check back in Spring Quarter for
+            applications.
+          </b>
+          <em>
+            Running for President, Internal VP, or External VP, requires that
+            you have already been a full-member for Fall, Winter, and Spring
+            Quarter.
+          </em>
         </div>
       </div>
     </Container>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
<img width="308" alt="Screenshot 2023-10-16 at 12 53 34 AM" src="https://github.com/icssc/icssc-website/assets/100006999/3229e1f7-3212-4d90-904c-45bfbc84d515">

There's two "apply to committee elements." I chose to keep the one on top for better visibility.

## Page Preview
<img width="308" alt="Screenshot 2023-10-16 at 12 55 09 AM" src="https://github.com/icssc/icssc-website/assets/100006999/6a98a8a0-72e7-4581-a771-482f1b230a1b">

## Test Plan
Hopefully it looks good

## Issues
Closes # 

## Misc
Sorry for the big diff, I've got prettier 😭

<!-- [Optional]
## Future Followup  
-->
