### PR TITLE
remove next export

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "export": "next build && next export"
+    "lint": "next lint"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.2.0",


### PR DESCRIPTION
## Summary
In Next.js v13.3.0, `next export` is deprecated and replaced with `"output": "export"`

Instead, running `next build`, generates an HTML file per route.
https://nextjs.org/docs/app/building-your-application/deploying/static-exports